### PR TITLE
Add agent-qa to 2024-2026 projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Agents (智能体) 精选资源合集，持续更新中
 |[SWE-agent](https://github.com/SWE-agent/SWE-agent)|![GitHub Repo stars](https://badgen.net/github/stars/SWE-agent/SWE-agent)|普林斯顿大学出品，让语言模型自主修复 GitHub Issue 的 Agent，在 SWE-bench 上表现出色。|
 |[Model Context Protocol (MCP)](https://github.com/modelcontextprotocol)|![GitHub Repo stars](https://badgen.net/github/stars/modelcontextprotocol/modelcontextprotocol)|Anthropic 提出的开放协议，为 LLM 与外部工具, 数据源的连接提供统一标准，已成为 Agent 生态事实标准。|
 |[Browser Use](https://github.com/browser-use/browser-use)|![GitHub Repo stars](https://badgen.net/github/stars/browser-use/browser-use)|让 AI Agent 像人一样操作浏览器，是当下最流行的网页自动化 Agent 工具之一。|
+|[agent-qa](https://github.com/vostride/agent-qa)|![GitHub Repo stars](https://badgen.net/github/stars/vostride/agent-qa)|面向软件团队的开源自进化 QA Agent，支持用自然语言编写并运行 Web 与移动端测试，通过跨运行记忆适应 UI 变化并发现回归问题。|
 |[smolagents](https://github.com/huggingface/smolagents)|![GitHub Repo stars](https://badgen.net/github/stars/huggingface/smolagents)|Hugging Face 推出的极简 Agent 库，核心仅约一千行代码，主打以代码形式编写 Agent 动作。|
 |[Pydantic AI](https://github.com/pydantic/pydantic-ai)|![GitHub Repo stars](https://badgen.net/github/stars/pydantic/pydantic-ai)|由 Pydantic 团队打造的 Agent 框架，强调类型安全与结构化输出，将 Pydantic 的工程体验带入 GenAI 开发。|
 |[A2A (Agent2Agent)](https://github.com/a2aproject/A2A)|![GitHub Repo stars](https://badgen.net/github/stars/a2aproject/A2A)|Google 发起的开放协议 (现由 Linux 基金会托管)，用于不同框架, 不同厂商的 Agent 之间互联互通。|


### PR DESCRIPTION
## Summary

Adds Agent QA to the 2024-2026 important projects table with the existing dynamic star badge format.

Agent QA is a source-available, self-improving QA agent for software teams. It supports natural-language web and mobile tests, retains execution memory across runs, adapts to UI changes, and helps detect regressions. Current releases use FSL-1.1-ALv2 and convert to Apache-2.0 after two years.

## Checks

- Repository and badge links return HTTP 200
- No duplicate Agent QA entry
- `git diff --check` passes

Disclosure: I am affiliated with Agent QA and Vostride and submitted the official project.

